### PR TITLE
Add variable endpoint versions

### DIFF
--- a/lib/monkeylearn/classifiers.rb
+++ b/lib/monkeylearn/classifiers.rb
@@ -40,7 +40,7 @@ module Monkeylearn
             if options.key? :production_model
               sliced_data[:production_model] = options[:production_model]
             end
-            request(:post, endpoint, sliced_data)
+            request(:post, endpoint, data: sliced_data)
           end
 
           return Monkeylearn::MultiResponse.new(responses)
@@ -49,12 +49,12 @@ module Monkeylearn
           if options.key? :production_model
               body[:production_model] = options[:production_model]
           end
-          return request(:post, endpoint, body)
+          return request(:post, endpoint, data: body)
         end
       end
 
       def list(options = {})
-        request(:get, build_endpoint, nil, options)
+        request(:get, build_endpoint, query_params: options)
       end
 
       def create(name, options = {})
@@ -72,7 +72,7 @@ module Monkeylearn
             stopwords: options[:stopwords],
             whitelist: options[:whitelist],
         }.delete_if { |k,v| v.nil? }
-        request(:post, build_endpoint, data)
+        request(:post, build_endpoint, data: data)
       end
 
       def edit(module_id, options = {})
@@ -90,7 +90,7 @@ module Monkeylearn
             stopwords: options[:stopwords],
             whitelist: options[:whitelist],
         }.delete_if { |k,v| v.nil? }
-        request(:patch, build_endpoint(module_id), data)
+        request(:patch, build_endpoint(module_id), data: data)
       end
 
       def detail(module_id)
@@ -104,7 +104,7 @@ module Monkeylearn
       def upload_data(module_id, data)
         endpoint = build_endpoint(module_id, 'data')
 
-        request(:post, endpoint, {data: data})
+        request(:post, endpoint, data: {data: data})
       end
 
       def delete(module_id)
@@ -128,7 +128,7 @@ module Monkeylearn
         if options[:parent_id]
           data[:parent_id] = options[:parent_id]
         end
-        request(:post, build_endpoint(module_id), data)
+        request(:post, build_endpoint(module_id), data: data)
       end
 
       def detail(module_id, tag_id)
@@ -152,7 +152,7 @@ module Monkeylearn
           data = {move_data_to: options[:move_data_to]}
         end
 
-        request(:delete, endpoint, data)
+        request(:delete, endpoint, data: data)
       end
     end
   end

--- a/lib/monkeylearn/classifiers.rb
+++ b/lib/monkeylearn/classifiers.rb
@@ -32,24 +32,38 @@ module Monkeylearn
         batch_size = options[:batch_size]
         validate_batch_size batch_size
 
+        api_version = validate_api_version(options[:api_version])
         endpoint = build_endpoint(model_id, 'classify')
+
+        request_preparator = lambda do |data|
+          case api_version
+          when :v2
+            body = { text_list: data }
+            query_params = if options[:sandbox]
+                             { sandbox: true }
+                           else
+                             nil
+                           end
+            return body, query_params
+          when :v3
+            body = { data: data }
+            if options.key? :production_model
+              body[:production_model] = options[:production_model]
+            end
+            return body, nil
+          end
+        end
 
         if Monkeylearn.auto_batch
           responses = (0...data.length).step(batch_size).collect do |start_idx|
-            sliced_data = { data: data[start_idx, batch_size] }
-            if options.key? :production_model
-              sliced_data[:production_model] = options[:production_model]
-            end
-            request(:post, endpoint, data: sliced_data)
+            sliced_data, query_params = request_preparator.call data[start_idx, batch_size]
+            request(:post, endpoint, data: sliced_data, query_params: query_params, api_version: api_version)
           end
 
           return Monkeylearn::MultiResponse.new(responses)
         else
-          body = {data: data}
-          if options.key? :production_model
-              body[:production_model] = options[:production_model]
-          end
-          return request(:post, endpoint, data: body)
+          body, query_params = request_preparator.call data
+          return request(:post, endpoint, data: body, query_params: query_params, api_version: api_version)
         end
       end
 

--- a/lib/monkeylearn/classifiers.rb
+++ b/lib/monkeylearn/classifiers.rb
@@ -97,6 +97,10 @@ module Monkeylearn
         request(:get, build_endpoint(module_id))
       end
 
+      def train(module_id)
+        request(:post, build_endpoint(module_id, 'train'), api_version: :v2)
+      end
+
       def deploy(module_id)
         request(:post, build_endpoint(module_id, 'deploy'))
       end

--- a/lib/monkeylearn/configurable.rb
+++ b/lib/monkeylearn/configurable.rb
@@ -2,12 +2,13 @@ require 'monkeylearn/defaults'
 
 module Monkeylearn
   module Configurable
-    attr_accessor :token, :base_url, :retry_if_throttle, :auto_batch
+    attr_accessor :token, :base_url, :api_version, :retry_if_throttle, :auto_batch
 
     class << self
       def keys
         @keys ||= [
           :base_url,
+          :api_version,
           :token,
           :retry_if_throttle,
           :auto_batch,

--- a/lib/monkeylearn/configurable.rb
+++ b/lib/monkeylearn/configurable.rb
@@ -3,7 +3,6 @@ require 'monkeylearn/defaults'
 module Monkeylearn
   module Configurable
     attr_accessor :token, :base_url, :retry_if_throttle, :auto_batch
-    attr_writer :base_url
 
     class << self
       def keys

--- a/lib/monkeylearn/defaults.rb
+++ b/lib/monkeylearn/defaults.rb
@@ -3,8 +3,10 @@ module Monkeylearn
     # Constants
     DEFAULT_BATCH_SIZE = 200
     MAX_BATCH_SIZE = 200
+    SUPPORTED_API_VERSIONS = [:v2, :v3]
     # Configurable options
-    BASE_URL = 'https://api.monkeylearn.com/v3/'
+    BASE_URL = 'https://api.monkeylearn.com/'
+    API_VERSION = SUPPORTED_API_VERSIONS.last
     RETRY_IF_THROTTLE = true
     AUTO_BATCH = true
 
@@ -15,6 +17,10 @@ module Monkeylearn
 
       def base_url
         ENV['MONKEYLEARN_API_BASE_URL'] || BASE_URL
+      end
+
+      def api_version
+        ENV['MONKEYLEARN_API_VERSION'] || API_VERSION
       end
 
       def token
@@ -35,6 +41,10 @@ module Monkeylearn
 
       def default_batch_size
         DEFAULT_BATCH_SIZE
+      end
+
+      def supported_api_versions
+        SUPPORTED_API_VERSIONS
       end
     end
   end

--- a/lib/monkeylearn/extractors.rb
+++ b/lib/monkeylearn/extractors.rb
@@ -36,7 +36,7 @@ module Monkeylearn
             if options.key? :production_model
               sliced_data[:production_model] = options[:production_model]
             end
-            request(:post, endpoint, sliced_data)
+            request(:post, endpoint, data: sliced_data)
           end
           return Monkeylearn::MultiResponse.new(responses)
         else
@@ -44,13 +44,13 @@ module Monkeylearn
           if options.key? :production_model
               body[:production_model] = options[:production_model]
           end
-          return request(:post, endpoint, body)
+          return request(:post, endpoint, data: body)
         end
 
       end
 
       def list(options = {})
-        request(:get, build_endpoint, nil, options)
+        request(:get, build_endpoint, query_params: options)
       end
 
       def detail(module_id)

--- a/lib/monkeylearn/requests.rb
+++ b/lib/monkeylearn/requests.rb
@@ -5,7 +5,7 @@ require 'monkeylearn/exceptions'
 
 module Monkeylearn
   module Requests
-    def request(method, path, data = nil, query_params = nil)
+    def request(method, path, data: nil, query_params: nil)
       unless Monkeylearn.token
         raise MonkeylearnError, 'Please initialize the Monkeylearn library with your API token'
       end

--- a/lib/monkeylearn/response.rb
+++ b/lib/monkeylearn/response.rb
@@ -35,7 +35,6 @@ module Monkeylearn
 
     def responses=(responses)
       @responses = responses
-      @query_limit_remaining = responses[-1].raw_response.headers['X-Query-Limit-Remaining'].to_i
       @plan_queries_allowed = @responses[-1].plan_queries_allowed
       @plan_queries_remaining = @responses[-1].plan_queries_remaining
       @request_queries_used = @responses.inject(0){|sum, r| sum + r.request_queries_used }

--- a/lib/monkeylearn/response.rb
+++ b/lib/monkeylearn/response.rb
@@ -27,17 +27,20 @@ module Monkeylearn
       self.responses = responses
     end
 
-    def body
-      responses.collect do |r|
-        r.body
-      end.reduce(:+)
-    end
-
     def responses=(responses)
       @responses = responses
+      @body = collect_body(responses)
       @plan_queries_allowed = @responses[-1].plan_queries_allowed
       @plan_queries_remaining = @responses[-1].plan_queries_remaining
       @request_queries_used = @responses.inject(0){|sum, r| sum + r.request_queries_used }
+    end
+
+    private
+
+    def collect_body(responses)
+      responses.collect do |r|
+        r.body
+      end.reduce(:+)
     end
   end
 end

--- a/lib/monkeylearn/response.rb
+++ b/lib/monkeylearn/response.rb
@@ -2,21 +2,36 @@ module Monkeylearn
   class Response
     attr_reader :raw_response, :status, :body, :plan_queries_allowed, :plan_queries_remaining, :request_queries_used
 
-    def initialize(raw_response)
+    def initialize(raw_response, api_version: nil)
+      @api_version = api_version || Monkeylearn::Defaults.api_version
       self.raw_response = raw_response
     end
 
     def raw_response=(raw_response)
       @raw_response = raw_response
       @status = raw_response.status
-      if raw_response.body != ''
-        @body = JSON.parse(raw_response.body, symbolize_keys: true)
-      else
-        @body = nil
-      end
+      @body = response_preparator(raw_response.body)
       @plan_queries_allowed = @raw_response.headers['X-Query-Limit-Limit'].to_i
       @plan_queries_remaining = @raw_response.headers['X-Query-Limit-Remaining'].to_i
       @request_queries_used = @raw_response.headers['X-Query-Limit-Request-Queries'].to_i
+    end
+
+    private
+
+    def response_preparator(body)
+      return nil if body == ''
+
+      case @api_version
+      when :v2
+        # For the original v2 response, everything remained nested inside the
+        # 'result' field. But, this was removed by the MutiResponse. As
+        # everything used to be a MultiResponse back then, let's just remove it
+        # here to better mimic that behavior. Also, this makes the code for the
+        # MultiResponse simpler.
+        JSON.parse(body)['result']
+      when :v3
+        JSON.parse(body, symbolize_keys: true)
+      end
     end
   end
 


### PR DESCRIPTION
This is an updated version of https://github.com/monkeylearn/monkeylearn-ruby/pull/17:

> Recently, I was upgrading the gem from `v0.2.1` to `v3.0.1` and I found a lot of breaking changes, mainly in the response formats of classifications and extractions. This makes the process really hard for large code bases.
>
> This patch enables applications to use different API versions for retrieving the classifications and extractions so users can gradually adopt the new v3 API. This patch does not change how the new/current gem handles the configuration of models or how training data is uploaded to a (classification) model.
>
> The patch also re-introduces the `train` method from `v0.2.1`. Under the hood, it just talks to the v2 endpoints of your back-end.
>
> I validated the patch by uploading some training samples to a v2 model and training it, but I'm not 100% sure that I didn't break anything. I would feel better, if there would be some testing framework.
>
> What do you think of it? I'd be happy to incorporate your feedback and iterate on this! 🙂

In the meantime I fixed and validated that `classify` and `extract` do work with the old version of the API. They may be used like this:
```
Monkeylearn.extractors.extract extractor_id, [other_text]
Monkeylearn.extractors.extract extractor_id, [other_text], api_version: :v2
```