### PR TITLE
DVX-11887: unlock `faraday` dependency from v. 0.17 to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # monkeylearn-ruby
+> Forked to unlock the [`faraday` gem](https://rubygems.org/gems/faraday) version dependency.
 
 Official Ruby client for the MonkeyLearn API. Build and consume machine learning models for language processing from your Ruby apps.
 

--- a/monkeylearn.gemspec
+++ b/monkeylearn.gemspec
@@ -10,9 +10,9 @@ Gem::Specification.new do |spec|
   spec.email = ['hello@monkeylearn.com']
   spec.homepage = 'https://github.com/monkeylearn/monkeylearn-ruby'
 
-  spec.version = '3.4.0'
+  spec.version = '3.4.0.1'
 
-  spec.add_dependency 'faraday', '>= 0.9.2', '< 1.0.0'
+  spec.add_dependency 'faraday', '>= 0.9.2', '< 2.0.0'
 
   spec.licenses = ['MIT']
 


### PR DESCRIPTION
ref: https://mydevex.atlassian.net/browse/DVX-11887